### PR TITLE
Initial debug testing fixes / typos

### DIFF
--- a/example-code/02-scale/ch05/ch05_init_deploy/README.md
+++ b/example-code/02-scale/ch05/ch05_init_deploy/README.md
@@ -8,6 +8,8 @@ The next step on the list is to fill in the variables in your **terraform.tfvars
 
 Ansible also requires some variables be set so don't forget to fill in **group_vars/*/vault.yml** with the appropriate info. You can use `ansible-vault encrypt` on the file if you'd like.
 
+<!-- TODO: Full Documentation Needed - examples, no dollar signs in galera passwords (fails the mysql cluster check script) -->
+
 **group_vars/all/vault.yml**
   * vault_ghost_db_name
   * vault_ghost_db_user
@@ -29,3 +31,6 @@ Ansible also requires some variables be set so don't forget to fill in **group_v
   * vault_sys_user
   * vault_ghost_service_user
   * vault_ghost_service_user_uid
+
+Execute the Ansible Playbook with the following command: ` ansible-playbook -i /usr/local/bin/terraform-inventory site.yml
+`

--- a/example-code/02-scale/ch05/ch05_init_deploy/roles/ghostbuild/templates/server-block.conf.j2
+++ b/example-code/02-scale/ch05/ch05_init_deploy/roles/ghostbuild/templates/server-block.conf.j2
@@ -1,5 +1,5 @@
 server {
-  listen {{ ansible_eth1.ipv4.address }}:80;
+  listen {{ ansible_eth0.ipv4.address }}:80;
   #listen [::]:80 default_server ipv6only=on;
 
   access_log /var/log/nginx/access.log;

--- a/example-code/02-scale/ch05/ch05_init_deploy/terraform.tfvars.sample
+++ b/example-code/02-scale/ch05/ch05_init_deploy/terraform.tfvars.sample
@@ -20,7 +20,7 @@ private_key_path = ""
 /* You can execute the following to grab your SSH key fingerprint - ssh-keygen -lf ~/.ssh/id_rsa -E md5 */
 ssh_fingerprint = ""
 
-/* cat your id_ras.pub file */
+/* cat your id_rsa.pub file */
 public_key = ""
 
 ansible_user = "ansible"


### PR DESCRIPTION
Initial pass to get the plan/playbook to initialize a ghost blog from
scratch. Assuming the eth1 was set for use with load balancers, but
right now the script deploys a single node.